### PR TITLE
Allow functional components to render `undefined`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -186,7 +186,7 @@ declare namespace RoactHooks {
 			}
 		) => (
 			props: P
-		) => Roact.Element;
+		) => Roact.Element | undefined;
 	}
 }
 


### PR DESCRIPTION
This change lets functional components render `undefined`. This is inline with traditional class components in Roact. For example, this is valid:
```ts
import Roact from "@rbxts/roact";

class MyComponent extends Roact.Component {
	public render() {
		return undefined;
	}
}

<MyComponent />;
```
However, doing a similar scenario with `roact-hooks` currently creates a compile error:
```
import Roact from "@rbxts/roact";
import RoactHooks from "@rbxts/roact-hooks";

const hooks = new RoactHooks(Roact);

const MyComponent = hooks(() => {
	return undefined;
});

<MyComponent />;
```
which raises the following error:
```
-- src/component.tsx:6:27 - error TS2345: Argument of type '() => undefined' is not assignable to parameter of type 'FC<{}>'.
--   Type 'undefined' is not assignable to type 'Element'.
-- 6 const MyComponent = hooks(() => {
--                             ~~~~~~~
```

Implementing this change will allow hooked components to render `undefined`.