### PR TITLE
Update Luau source to latest main branch

### DIFF
--- a/src/createUseBinding.lua
+++ b/src/createUseBinding.lua
@@ -1,5 +1,5 @@
 local function createUseBinding(roact, useValue)
-	return function(defaultValue)
+	return function<T>(defaultValue: T): (any, (newValue: T) -> ())
 		return unpack(useValue({
 			roact.createBinding(defaultValue)
 		}).value)

--- a/src/createUseCallback.lua
+++ b/src/createUseCallback.lua
@@ -1,5 +1,8 @@
+type DependencyList = { unknown }
+type Function<Args..., Rets...> = (Args...) -> Rets...
+
 local function createUseCallback(useMemo)
-	return function(callback, dependencies)
+	return function<Args..., Rets...>(callback: Function<Args..., Rets...>, dependencies: DependencyList?): Function<Args..., Rets...>
 		return useMemo(function()
 			return callback
 		end, dependencies)

--- a/src/createUseContext.lua
+++ b/src/createUseContext.lua
@@ -1,4 +1,4 @@
-local function createUseContext(component, useEffect, useState)
+local function createUseContext(component, useEffect, useState, useMemo)
 	-- HACK: I'd like to just use the values from the consumers directly.
 	-- However, we don't know what contexts to listen to until `useContext` is called.
 	-- Thus, we do this insanely unstable method for doing it. :)
@@ -7,20 +7,36 @@ local function createUseContext(component, useEffect, useState)
 	})
 
 	return function(context)
+		local defaultValue = useMemo(function()
+			local initialValue
+
+			fakeConsumer.props = {
+				render = function(value)
+					initialValue = value
+				end,
+			}
+
+			context.Consumer.render(fakeConsumer)
+			return initialValue
+		end, {})
+
 		context.Consumer.init(fakeConsumer)
 
 		local contextEntry = fakeConsumer.contextEntry
-		local value, setValue = useState(if contextEntry == nil then nil else contextEntry.value)
+		local value, setValue = useState(if contextEntry == nil then defaultValue else contextEntry.value)
 
 		useEffect(function()
 			if contextEntry == nil then
+				if value ~= defaultValue then
+					setValue(defaultValue)
+				end
 				return
 			end
 
 			if value ~= contextEntry.value then
 				setValue(contextEntry.value)
 			end
-			
+
 			return contextEntry.onUpdate:subscribe(setValue)
 		end, { contextEntry })
 

--- a/src/createUseEffect.lua
+++ b/src/createUseEffect.lua
@@ -1,5 +1,9 @@
+type Destructor = () -> ()
+type EffectCallback = (() -> Destructor) | (() -> ())
+type DependencyList = { unknown }
+
 local function createUseEffect(component)
-	return function(callback, dependsOn)
+	return function(callback: EffectCallback, dependsOn: DependencyList?)
 		assert(typeof(callback) == "function", "useEffect callback is not a function")
 
 		component.hookCounter += 1

--- a/src/createUseMemo.lua
+++ b/src/createUseMemo.lua
@@ -1,7 +1,9 @@
 local dependenciesDifferent = require(script.Parent.dependenciesDifferent)
 
+type DependencyList = { unknown }
+
 local function createUseMemo(useValue)
-	return function(createValue, dependencies)
+	return function<T...>(createValue: () -> T..., dependencies: DependencyList?): T...
 		local currentValue = useValue(nil)
 
 		local needToRecalculate = dependencies == nil

--- a/src/createUseReducer.lua
+++ b/src/createUseReducer.lua
@@ -1,5 +1,7 @@
+type Reducer<S, A> = (state: S, action: A) -> S
+
 local function createUseReducer(useCallback, useState)
-	return function(reducer, initialState)
+	return function<S, A>(reducer: Reducer<S, A>, initialState: S): (S, (action: A) -> ())
 		local state, setState = useState(initialState)
 		local dispatch = useCallback(function(action)
 			setState(reducer(state, action))

--- a/src/createUseState.lua
+++ b/src/createUseState.lua
@@ -8,10 +8,13 @@ local function extractValue(valueOrCallback, currentValue)
 	end
 end
 
+type SetStateAction<S> = S | ((prevState: S) -> S)
+type Dispatch<T> = (value: T) -> ()
+
 local function createUseState(component)
 	local setValues = {}
 
-	return function(defaultValue)
+	return function<T>(defaultValue: T | (() -> T)): (T, Dispatch<SetStateAction<T>>)
 		component.hookCounter += 1
 		local hookCount = component.hookCounter
 		local value = component.state[hookCount]

--- a/src/init.lua
+++ b/src/init.lua
@@ -16,9 +16,9 @@ local function createHooks(roact, component)
 	local useValue = createUseValue(component)
 
 	local useBinding = createUseBinding(roact, useValue)
-	local useContext = createUseContext(component, useEffect, useState)
 	local useMemo = createUseMemo(useValue)
 
+	local useContext = createUseContext(component, useEffect, useState, useMemo)
 	local useCallback = createUseCallback(useMemo)
 
 	local useReducer = createUseReducer(useCallback, useState)
@@ -36,8 +36,18 @@ local function createHooks(roact, component)
 	}
 end
 
-function Hooks.new(roact)
-	return function(render, options)
+export type Hooks = typeof(createHooks())
+export type HookOptions<Props> = {
+	name: string?,
+	defaultProps: { [string]: any }?,
+	componentType: "Component" | "PureComponent" | nil,
+	validateProps: ((props: Props) -> (boolean, string?))?,
+	[string]: { NO_EXTRA_ARGS: never },
+}
+export type RenderFunction<Props> = (props: Props, hooks: Hooks) -> any
+
+function Hooks.new<Props>(roact)
+	return function(render: RenderFunction<Props>, options: HookOptions<Props>?)
 		assert(typeof(render) == "function", "Hooked components must be functions.")
 
 		if options == nil then


### PR DESCRIPTION
Adds the changes from
bcdf9dbd989bd934888365f99178e1f53e06c642..b3d8bdf63de253d150fa04a6edf25c2614964965 to the repository.

This should probably be released under something alike `0.5.1`. `0.5.0` included Luau types (not relevant for us), but the latter commit involves an unreleased change (likely to be `0.5.1`).